### PR TITLE
fix: display weekly progress scores as percentages

### DIFF
--- a/src/components/student/WeeklyProgressChart.tsx
+++ b/src/components/student/WeeklyProgressChart.tsx
@@ -18,7 +18,7 @@ const getBarColor = (score: number): string => {
 export const WeeklyProgressChart = ({ weeklyData }: WeeklyProgressChartProps) => {
   const chartData = weeklyData.map((week) => ({
     name: `W${week.week}`,
-    score: (week as { totalScore?: number }).totalScore || 0,
+    score: Math.round(week.totalScore * 100 / week.maxTotalScore), // Convert to percentage
     max: 100,
   }));
 

--- a/src/types/student.ts
+++ b/src/types/student.ts
@@ -67,6 +67,8 @@ export interface WeeklyData {
   bonusScore: BonusScore;
   exerciseScore: ExerciseScore;
   total: number;
+  totalScore: number;
+  maxTotalScore: number;
   group: string;
   ta: string;
 }


### PR DESCRIPTION
## Summary
- Convert weekly progress chart from displaying raw scores to percentages (`totalScore * 100 / maxTotalScore`)
- Add `totalScore` and `maxTotalScore` fields to the `WeeklyData` type interface
- Remove unsafe type assertion that was previously used as a workaround

## Test plan
- [ ] Verify the weekly progress chart displays percentage values (0–100) instead of raw scores
- [ ] Confirm the chart renders correctly with real student data

🤖 Generated with [Claude Code](https://claude.com/claude-code)