### PR TITLE
refactor: simplify student detail page URLs to path params

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -56,7 +56,7 @@ const router = createBrowserRouter([
     element: <Layout><TableView /></Layout>,
   },
   {
-    path: '/detailPage',
+    path: '/student/:studentId/:cohortId',
     element: <Layout><StudentDetailPage /></Layout>,
   },
   {

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -158,14 +158,7 @@ export const ResultPage: React.FC = () => {
   const handleStudentClick = useCallback(
     (student: StudentResult) => {
       if (!cohortData) return;
-      navigate(
-        `/detailPage?studentId=${student.userId}` +
-          `&cohortType=${cohortData.type}` +
-          `&cohortId=${cohortData.id}` +
-          `&studentName=${encodeURIComponent(student.name)}` +
-          `&studentDiscord=${encodeURIComponent(student.discordUsername)}` +
-          `&from=results`,
-      );
+      navigate(`/student/${student.userId}/${cohortData.id}`);
     },
     [navigate, cohortData],
   );

--- a/src/pages/StudentDetailPage.tsx
+++ b/src/pages/StudentDetailPage.tsx
@@ -1,5 +1,5 @@
-import { useState, useMemo } from 'react';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useMemo } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
 import {
   Box,
   Typography,
@@ -73,20 +73,9 @@ interface ScoresData {
   maxTotalScore: number;
 }
 
-interface StudentInfo {
-  name: string;
-  email: string;
-}
-
 const StudentDetailPage = () => {
-  const [searchParams] = useSearchParams();
+  const { studentId, cohortId: cohortIdParam } = useParams<{ studentId: string; cohortId: string }>();
   const navigate = useNavigate();
-  const [studentInfo, setStudentInfo] = useState<StudentInfo | null>(null);
-
-  const cohortIdParam = searchParams.get('cohortId');
-  const cohortTypeParam = searchParams.get('cohortType');
-  const studentId = searchParams.get('studentId');
-  const fromSource = searchParams.get('from');
 
   const { data: cohortData } = useCohort(cohortIdParam);
   const { data: currentUser } = useUser();
@@ -101,23 +90,14 @@ const StudentDetailPage = () => {
 
   const { data: studentProfileData } = useUserById(studentId || '', { enabled: canViewOtherScores && !!studentId });
 
-  // Set student info from URL params
-  useState(() => {
-    const studentName = searchParams.get('studentName');
-    const studentEmail = searchParams.get('studentEmail');
-    if (studentName || studentEmail) {
-      setStudentInfo({
-        name: studentName || 'Unknown',
-        email: studentEmail || 'N/A',
-      });
-    }
-  });
+  const displayName = isViewingOwnProfile
+    ? (currentUser?.name || currentUser?.discordUsername || 'Unknown')
+    : (studentProfileData?.name || studentProfileData?.discordUsername || '');
+  const displayEmail = isViewingOwnProfile
+    ? currentUser?.email
+    : studentProfileData?.email;
 
-  const selectedCohort = scoresData?.cohorts.find(cohort => {
-    if (cohortIdParam) return cohort.cohortId === cohortIdParam;
-    if (cohortTypeParam) return cohort.cohortType === cohortTypeParam;
-    return false;
-  }) || scoresData?.cohorts[0];
+  const selectedCohort = scoresData?.cohorts.find(cohort => cohort.cohortId === cohortIdParam) || scoresData?.cohorts[0];
 
   const sortedCohortWeeks = useMemo(() => {
     if (!cohortData?.weeks) return [];
@@ -147,7 +127,7 @@ const StudentDetailPage = () => {
 
   const totalWeeks = sortedWeeklyScores.length || 0;
   const attendedWeeks = sortedWeeklyScores.filter(w => w.attended ?? w.groupDiscussionScores?.attendance).length || 0;
-  const hasExercises = cohortHasExercises(selectedCohort?.cohortType || '');
+  const hasExercises = cohortHasExercises(cohortData?.type || selectedCohort?.cohortType || '');
 
   const stats = {
     totalScore: selectedCohort?.totalScore || 0,
@@ -220,15 +200,15 @@ const StudentDetailPage = () => {
         </Button>
 
         {/* Header */}
-        {studentInfo && (
+        {(displayName || displayEmail) && (
           <Box sx={{ mb: 3 }}>
             <Box sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, justifyContent: 'space-between', gap: 2 }}>
               <Box>
                 <Typography variant="h5" sx={{ fontWeight: 700, color: '#fff', fontSize: { xs: '1.5rem', sm: '1.75rem' } }}>
-                  {studentInfo.name}
+                  {displayName}
                 </Typography>
                 <Typography variant="body2" sx={{ color: '#a1a1aa', mt: 0.5 }}>
-                  {isViewingOwnProfile ? studentInfo.email : studentInfo.email}
+                  {displayEmail}
                 </Typography>
                 {selectedCohort && (
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1 }}>
@@ -247,44 +227,42 @@ const StudentDetailPage = () => {
               </Box>
 
               {/* Action buttons */}
-              {!fromSource && (
-                <Box sx={{ display: 'flex', gap: 1.5, flexWrap: 'wrap', alignItems: 'flex-start' }}>
-                  {selectedCohort && (selectedCohort.cohortType === "MASTERING_BITCOIN" || selectedCohort.cohortType === "LEARNING_BITCOIN_FROM_COMMAND_LINE" || selectedCohort.cohortType === "MASTERING_LIGHTNING_NETWORK" || selectedCohort.cohortType === "BITCOIN_PROTOCOL_DEVELOPMENT") && (
-                    <Button
-                      variant="contained"
-                      size="small"
-                      startIcon={<BookOpen size={16} />}
-                      onClick={() => {
-                        if (selectedCohort.cohortId) {
-                          navigate(`/${selectedCohort.cohortId}/instructions`);
-                        } else if (selectedCohort.cohortType === "MASTERING_BITCOIN") {
-                          navigate('/mb-instructions');
-                        } else if (selectedCohort.cohortType === "LEARNING_BITCOIN_FROM_COMMAND_LINE") {
-                          navigate('/lbtcl-instructions');
-                        } else if (selectedCohort.cohortType === "MASTERING_LIGHTNING_NETWORK") {
-                          navigate('/ln-instructions');
-                        } else if (selectedCohort.cohortType === "BITCOIN_PROTOCOL_DEVELOPMENT") {
-                          navigate('/bpd-instructions');
-                        }
-                      }}
-                      sx={{ bgcolor: '#ea580c', textTransform: 'none', fontWeight: 600, boxShadow: 'none', '&:hover': { bgcolor: '#c2410c' } }}
-                    >
-                      Instructions
-                    </Button>
-                  )}
-                  {cohortIdParam && (
-                    <Button
-                      variant="outlined"
-                      size="small"
-                      startIcon={<Trophy size={16} />}
-                      onClick={() => navigate(`/results/${cohortIdParam}`)}
-                      sx={{ color: '#fb923c', borderColor: 'rgba(249,115,22,0.4)', textTransform: 'none', fontWeight: 600, '&:hover': { borderColor: '#fb923c', bgcolor: 'rgba(249,115,22,0.08)' } }}
-                    >
-                      View Ranking
-                    </Button>
-                  )}
-                </Box>
-              )}
+              <Box sx={{ display: 'flex', gap: 1.5, flexWrap: 'wrap', alignItems: 'flex-start' }}>
+                {selectedCohort && (selectedCohort.cohortType === "MASTERING_BITCOIN" || selectedCohort.cohortType === "LEARNING_BITCOIN_FROM_COMMAND_LINE" || selectedCohort.cohortType === "MASTERING_LIGHTNING_NETWORK" || selectedCohort.cohortType === "BITCOIN_PROTOCOL_DEVELOPMENT") && (
+                  <Button
+                    variant="contained"
+                    size="small"
+                    startIcon={<BookOpen size={16} />}
+                    onClick={() => {
+                      if (selectedCohort.cohortId) {
+                        navigate(`/${selectedCohort.cohortId}/instructions`);
+                      } else if (selectedCohort.cohortType === "MASTERING_BITCOIN") {
+                        navigate('/mb-instructions');
+                      } else if (selectedCohort.cohortType === "LEARNING_BITCOIN_FROM_COMMAND_LINE") {
+                        navigate('/lbtcl-instructions');
+                      } else if (selectedCohort.cohortType === "MASTERING_LIGHTNING_NETWORK") {
+                        navigate('/ln-instructions');
+                      } else if (selectedCohort.cohortType === "BITCOIN_PROTOCOL_DEVELOPMENT") {
+                        navigate('/bpd-instructions');
+                      }
+                    }}
+                    sx={{ bgcolor: '#ea580c', textTransform: 'none', fontWeight: 600, boxShadow: 'none', '&:hover': { bgcolor: '#c2410c' } }}
+                  >
+                    Instructions
+                  </Button>
+                )}
+                {cohortIdParam && (
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    startIcon={<Trophy size={16} />}
+                    onClick={() => navigate(`/results/${cohortIdParam}`)}
+                    sx={{ color: '#fb923c', borderColor: 'rgba(249,115,22,0.4)', textTransform: 'none', fontWeight: 600, '&:hover': { borderColor: '#fb923c', bgcolor: 'rgba(249,115,22,0.08)' } }}
+                  >
+                    View Ranking
+                  </Button>
+                )}
+              </Box>
             </Box>
           </Box>
         )}

--- a/src/pages/TableView.tsx
+++ b/src/pages/TableView.tsx
@@ -279,11 +279,9 @@ const TableView: React.FC = () => {
 
   const handleStudentClick = useCallback((student: TableRowData) => {
     const studentId = student.userId ?? student.id;
-    const cohortType = cohortData?.type;
     const cohortId = cohortData?.id;
-    const studentName = encodeURIComponent(student.name);
-    navigate(`/detailPage?studentId=${studentId}&cohortType=${cohortType}&cohortId=${cohortId}&studentName=${studentName}&from=table`);
-  }, [navigate, cohortData?.type, cohortData?.id]);
+    navigate(`/student/${studentId}/${cohortId}`);
+  }, [navigate, cohortData?.id]);
 
   const handleEditStudent = useCallback((student: TableRowData) => {
     setSelectedStudentForEdit(student);

--- a/src/pages/myProfile/myStudentDashboard.tsx
+++ b/src/pages/myProfile/myStudentDashboard.tsx
@@ -336,14 +336,7 @@ const MyStudentDashboard = () => {
           onRowClick={(cohort) => {
             const row = cohort as DashboardCohortRow;
             if (row.enrolled && userData?.id) {
-              const params = new URLSearchParams({
-                studentId: userData.id,
-                cohortType: row.type,
-                cohortId: row.id,
-                ...(userData.name && { studentName: userData.name }),
-                ...(userData.email && { studentEmail: userData.email }),
-              });
-              navigate(`/detailPage?${params.toString()}`);
+              navigate(`/student/${userData.id}/${row.id}`);
             }
           }}
           actions={(cohort) => {
@@ -359,14 +352,7 @@ const MyStudentDashboard = () => {
                       size="small"
                       onClick={() => {
                         if (userData?.id) {
-                          const params = new URLSearchParams({
-                            studentId: userData.id,
-                            cohortType: row.type,
-                            cohortId: row.id,
-                            ...(userData.name && { studentName: userData.name }),
-                            ...(userData.email && { studentEmail: userData.email }),
-                          });
-                          navigate(`/detailPage?${params.toString()}`);
+                          navigate(`/student/${userData.id}/${row.id}`);
                         }
                       }}
                       sx={{


### PR DESCRIPTION
Replace long query strings (?studentId=...&cohortType=...&studentName=...&from=...) with clean path-based routing (/student/:studentId/:cohortId). Student name/email now sourced from API instead of URL params.