### PR TITLE
feat: separate certificate generation and email sending

### DIFF
--- a/src/hooks/certificateHooks.ts
+++ b/src/hooks/certificateHooks.ts
@@ -55,6 +55,10 @@ export const useGenerateCohortCertificates = createUseMutation<
   },
 );
 
+export const useSendCohortCertificateEmails = createUseMutation<void, { cohortId: string }>(
+  ({ cohortId }) => apiService.sendCohortCertificateEmails(cohortId),
+);
+
 export const useDownloadCertificate = createUseMutation<Blob, { id: string }>(
   ({ id }) => apiService.downloadCertificate(id),
 );

--- a/src/pages/CohortSelection.tsx
+++ b/src/pages/CohortSelection.tsx
@@ -35,7 +35,7 @@ import {
 import { Tooltip } from '@mui/material';
 import { useCohorts, useCreateCohort, useUpdateCohort } from '../hooks/cohortHooks';
 import { useUser } from '../hooks/userHooks';
-import { useGenerateCohortCertificates, useCohortCertificates, usePreviewCohortCertificates } from '../hooks/certificateHooks';
+import { useGenerateCohortCertificates, useCohortCertificates, usePreviewCohortCertificates, useSendCohortCertificateEmails } from '../hooks/certificateHooks';
 import type { CertificatePreviewResponseDto } from '../types/api';
 import apiService from '../services/apiService';
 import { UserRole, CohortType } from '../types/enums';
@@ -116,13 +116,17 @@ const CertificatePreviewModal = ({
   cohortName,
   onClose,
   onGenerate,
+  onSendEmails,
   isGenerating,
+  isSendingEmails,
 }: {
   cohortId: string;
   cohortName: string;
   onClose: () => void;
   onGenerate: () => void;
+  onSendEmails: () => void;
   isGenerating: boolean;
+  isSendingEmails: boolean;
 }) => {
   const { data: previews, isLoading } = usePreviewCohortCertificates(cohortId);
 
@@ -340,6 +344,22 @@ const CertificatePreviewModal = ({
           Close
         </Button>
         <Button
+          onClick={() => { onSendEmails(); onClose(); }}
+          variant="outlined"
+          disabled={isSendingEmails || isLoading || !previews || previews.length === 0}
+          startIcon={isSendingEmails ? <CircularProgress size={13} sx={{ color: '#60a5fa' }} /> : undefined}
+          sx={{
+            color: '#60a5fa',
+            borderColor: '#3b82f6',
+            textTransform: 'none',
+            fontWeight: 600,
+            '&:hover': { borderColor: '#60a5fa', bgcolor: 'rgba(96,165,250,0.08)' },
+            '&.Mui-disabled': { borderColor: '#1e3a5f', color: '#1e40af' },
+          }}
+        >
+          Send Emails
+        </Button>
+        <Button
           onClick={() => { onGenerate(); onClose(); }}
           variant="contained"
           disabled={isGenerating || isLoading || !previews || previews.length === 0}
@@ -388,6 +408,8 @@ export const CohortSelection = () => {
   const createCohortMutation = useCreateCohort();
   const updateCohortMutation = useUpdateCohort();
   const { mutate: generateCertificates, isPending: isGeneratingCerts } = useGenerateCohortCertificates();
+  const { mutate: sendCertificateEmails, isPending: isSendingCertEmails } = useSendCohortCertificateEmails();
+  const [sendingEmailsCohortId, setSendingEmailsCohortId] = useState<string | null>(null);
 
   const [activeTab, setActiveTab] = useState<string>('Active');
   const [generatingCohortId, setGeneratingCohortId] = useState<string | null>(null);
@@ -527,6 +549,28 @@ export const CohortSelection = () => {
     );
   };
 
+
+  const handleSendCertificateEmails = (cohortId: string, cohortName: string) => {
+    setSendingEmailsCohortId(cohortId);
+    sendCertificateEmails(
+      { cohortId },
+      {
+        onSuccess: () => {
+          setSendingEmailsCohortId(null);
+          setSnackbar({ open: true, message: `Certificate emails sent for ${cohortName}!`, severity: 'success' });
+        },
+        onError: (error) => {
+          setSendingEmailsCohortId(null);
+          let errorMessage = 'Failed to send certificate emails.';
+          if (typeof error === 'object' && error !== null && 'response' in error) {
+            const re = error as { response?: { data?: { message?: string } } };
+            if (re.response?.data?.message) errorMessage = re.response.data.message;
+          }
+          setSnackbar({ open: true, message: errorMessage, severity: 'error' });
+        },
+      },
+    );
+  };
 
   const closeModal = () => {
     setIsModalOpen(false);
@@ -866,7 +910,9 @@ export const CohortSelection = () => {
           cohortName={previewCohort.name}
           onClose={() => setPreviewCohort(null)}
           onGenerate={() => handleGenerateCertificates(previewCohort.id, previewCohort.name)}
+          onSendEmails={() => handleSendCertificateEmails(previewCohort.id, previewCohort.name)}
           isGenerating={isGeneratingCerts && generatingCohortId === previewCohort.id}
+          isSendingEmails={isSendingCertEmails && sendingEmailsCohortId === previewCohort.id}
         />
       )}
 

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -384,6 +384,14 @@ class ApiService {
     });
   };
 
+  public sendCohortCertificateEmails = async (cohortId: string): Promise<void> => {
+    await this.request<void>({
+      headers: this.getRequestHeaders(),
+      method: 'POST',
+      url: `/certificates/cohort/${cohortId}/send-emails`,
+    });
+  };
+
   public previewCohortCertificates = async (cohortId: string): Promise<CertificatePreviewResponseDto[]> => {
     const { data } = await this.request<CertificatePreviewResponseDto[]>({
       headers: this.getRequestHeaders(),


### PR DESCRIPTION
Add a dedicated Send Emails button to the certificate preview modal, backed by a new POST /certificates/cohort/:id/send-emails endpoint, so generation and email delivery are independent actions.