### PR TITLE
fix: skip query retries on 401 for immediate logout

### DIFF
--- a/src/services/queryClientFactory.tsx
+++ b/src/services/queryClientFactory.tsx
@@ -23,7 +23,10 @@ export const createQueryClient = () => {
             isNetworkError(error as AxiosError)
               ? Math.min(2500 * 2 ** failureCount, 30000)
               : defaultRetryDelay(failureCount),
-          retry(failureCount) {
+          retry(failureCount, error) {
+            if (axios.isAxiosError(error) && error.response?.status === 401) {
+              return false;
+            }
             return failureCount < 3;
           },
         },


### PR DESCRIPTION
## Summary
- Skip React Query retries when a 401 Unauthorized response is received
- Previously, the default retry(3) config would retry 401s with exponential backoff before logging out, causing unnecessary API requests when the auth token is invalid

## Test plan
- [ ] Log in, then invalidate/clear the auth token manually
- [ ] Verify that only a single 401 request is made before redirect to login (no retries)
- [ ] Verify that non-401 errors still retry up to 3 times as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)