### PR TITLE
fix(instructions): read classroomAssignmentUrl from API for assignment links

### DIFF
--- a/src/components/instructions/CohortInstructions.tsx
+++ b/src/components/instructions/CohortInstructions.tsx
@@ -84,7 +84,7 @@ const CohortInstructions: React.FC<CohortInstructionsProps> = ({
     [cohortId],
   );
 
-  // Merge API week data (questions, bonusQuestion, classroomUrl, classroomInviteLink) into static content
+  // Merge API week data (questions, bonusQuestion, classroomAssignmentUrl, classroomInviteLink) into static content
   const mergedWeeklyContent = React.useMemo(() => {
     const apiWeeks = apiCohort?.weeks;
     if (!apiWeeks || apiWeeks.length === 0) return weeklyContent;
@@ -97,7 +97,7 @@ const CohortInstructions: React.FC<CohortInstructionsProps> = ({
         ...staticWeek,
         gdQuestions: apiWeek.questions.length > 0 ? toRichQuestions(apiWeek.questions) : staticWeek.gdQuestions,
         bonusQuestions: apiWeek.bonusQuestion.length > 0 ? toRichQuestions(apiWeek.bonusQuestion) : staticWeek.bonusQuestions,
-        classroomUrl: apiWeek.classroomUrl,
+        classroomUrl: apiWeek.classroomAssignmentUrl,
         classroomInviteLink: apiWeek.classroomInviteLink,
       };
     });

--- a/src/components/table/TableHeader.tsx
+++ b/src/components/table/TableHeader.tsx
@@ -36,7 +36,7 @@ interface Week {
   hasExercise: boolean;
   questions: { text: string; attachments: string[] }[];
   bonusQuestion: { text: string; attachments: string[] }[];
-  classroomUrl: string;
+  classroomAssignmentUrl: string;
   classroomInviteLink: string;
 }
 

--- a/src/data/mockTableData.ts
+++ b/src/data/mockTableData.ts
@@ -66,12 +66,12 @@ export function generateMockTableData(weekNumber: number, count = 16): TableRowD
 }
 
 export const mockWeeks = [
-  { id: 'mock-week-1', week: 1, type: 'GROUP_DISCUSSION', hasExercise: true, questions: ['What is Bitcoin?'], bonusQuestion: ['Explain PoW'], classroomUrl: null, classroomInviteLink: null },
-  { id: 'mock-week-2', week: 2, type: 'GROUP_DISCUSSION', hasExercise: true, questions: ['What are UTXOs?'], bonusQuestion: ['Explain Merkle trees'], classroomUrl: null, classroomInviteLink: null },
-  { id: 'mock-week-3', week: 3, type: 'GROUP_DISCUSSION', hasExercise: false, questions: ['Explain Script'], bonusQuestion: ['SegWit benefits'], classroomUrl: null, classroomInviteLink: null },
-  { id: 'mock-week-4', week: 4, type: 'GROUP_DISCUSSION', hasExercise: true, questions: ['What is a soft fork?'], bonusQuestion: ['Taproot overview'], classroomUrl: null, classroomInviteLink: null },
-  { id: 'mock-week-5', week: 5, type: 'GROUP_DISCUSSION', hasExercise: false, questions: ['Lightning basics'], bonusQuestion: ['HTLC routing'], classroomUrl: null, classroomInviteLink: null },
-  { id: 'mock-week-6', week: 6, type: 'GROUP_DISCUSSION', hasExercise: true, questions: ['P2P networking'], bonusQuestion: ['Eclipse attacks'], classroomUrl: null, classroomInviteLink: null },
-  { id: 'mock-week-7', week: 7, type: 'GROUP_DISCUSSION', hasExercise: false, questions: ['Mining pools'], bonusQuestion: ['Stratum V2'], classroomUrl: null, classroomInviteLink: null },
-  { id: 'mock-week-8', week: 8, type: 'GROUP_DISCUSSION', hasExercise: true, questions: ['Bitcoin privacy'], bonusQuestion: ['CoinJoin analysis'], classroomUrl: null, classroomInviteLink: null },
+  { id: 'mock-week-1', week: 1, type: 'GROUP_DISCUSSION', hasExercise: true, questions: ['What is Bitcoin?'], bonusQuestion: ['Explain PoW'], classroomAssignmentUrl: null, classroomInviteLink: null },
+  { id: 'mock-week-2', week: 2, type: 'GROUP_DISCUSSION', hasExercise: true, questions: ['What are UTXOs?'], bonusQuestion: ['Explain Merkle trees'], classroomAssignmentUrl: null, classroomInviteLink: null },
+  { id: 'mock-week-3', week: 3, type: 'GROUP_DISCUSSION', hasExercise: false, questions: ['Explain Script'], bonusQuestion: ['SegWit benefits'], classroomAssignmentUrl: null, classroomInviteLink: null },
+  { id: 'mock-week-4', week: 4, type: 'GROUP_DISCUSSION', hasExercise: true, questions: ['What is a soft fork?'], bonusQuestion: ['Taproot overview'], classroomAssignmentUrl: null, classroomInviteLink: null },
+  { id: 'mock-week-5', week: 5, type: 'GROUP_DISCUSSION', hasExercise: false, questions: ['Lightning basics'], bonusQuestion: ['HTLC routing'], classroomAssignmentUrl: null, classroomInviteLink: null },
+  { id: 'mock-week-6', week: 6, type: 'GROUP_DISCUSSION', hasExercise: true, questions: ['P2P networking'], bonusQuestion: ['Eclipse attacks'], classroomAssignmentUrl: null, classroomInviteLink: null },
+  { id: 'mock-week-7', week: 7, type: 'GROUP_DISCUSSION', hasExercise: false, questions: ['Mining pools'], bonusQuestion: ['Stratum V2'], classroomAssignmentUrl: null, classroomInviteLink: null },
+  { id: 'mock-week-8', week: 8, type: 'GROUP_DISCUSSION', hasExercise: true, questions: ['Bitcoin privacy'], bonusQuestion: ['CoinJoin analysis'], classroomAssignmentUrl: null, classroomInviteLink: null },
 ];

--- a/src/pages/myProfile/myCohortInstructions.tsx
+++ b/src/pages/myProfile/myCohortInstructions.tsx
@@ -71,7 +71,7 @@ const MyCohortInstructions: React.FC = () => {
         ...staticWeek,
         gdQuestions: apiWeek.questions.length > 0 ? toRichQuestions(cohortData.id, apiWeek.questions) : staticWeek.gdQuestions,
         bonusQuestions: apiWeek.bonusQuestion.length > 0 ? toRichQuestions(cohortData.id, apiWeek.bonusQuestion) : staticWeek.bonusQuestions,
-        classroomUrl: apiWeek.classroomUrl,
+        classroomUrl: apiWeek.classroomAssignmentUrl,
         classroomInviteLink: apiWeek.classroomInviteLink,
       };
     });

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -29,7 +29,7 @@ export interface CohortWeekQuestion {
 export interface UpdateCohortWeekRequestDto {
   questions?: { text: string; attachments?: string[] }[] | undefined;
   bonusQuestion?: { text: string; attachments?: string[] }[] | undefined;
-  classroomUrl?: string | undefined;
+  classroomAssignmentUrl?: string | undefined;
   classroomInviteLink?: string | undefined;
   scheduledDate?: string | undefined;
 }
@@ -45,7 +45,7 @@ export interface GetCohortWeekResponseDto {
   hasExercise: boolean;
   questions: CohortWeekQuestion[];
   bonusQuestion: CohortWeekQuestion[];
-  classroomUrl: string | null;
+  classroomAssignmentUrl: string | null;
   classroomInviteLink: string | null;
   scheduledDate: string | null;
 }


### PR DESCRIPTION
## Problem

The GitHub Classroom assignment link in the cohort instruction sheet (both the **week tab** and the **exercises tab**) displayed a stale/hardcoded link instead of the value coming from the API.

## Root cause

A field-name mismatch. The API returns the assignment link as **`classroomAssignmentUrl`**, but the frontend type and merge code read **`classroomUrl`**. As a result `apiWeek.classroomUrl` was always `undefined`, the merge wrote `undefined`, and `getAssignmentLink()` fell back to the static `assignmentLinks` in `src/data/*Weeks.ts` — which resolved to a previous season's link (e.g. LN season 3 showed the season-2 `…/a/djNG7OtA` link). `classroomInviteLink` was unaffected because that field name already matched.

## Fix

Corrected the field name everywhere the API response shape is consumed:

- `src/types/api.ts` — `GetCohortWeekResponseDto.classroomAssignmentUrl` (response) and `UpdateCohortWeekRequestDto.classroomAssignmentUrl` (request, for consistency)
- `src/components/instructions/CohortInstructions.tsx` — merge maps from `apiWeek.classroomAssignmentUrl`
- `src/pages/myProfile/myCohortInstructions.tsx` — same merge fix
- `src/components/table/TableHeader.tsx` — local `Week` type kept consistent
- `src/data/mockTableData.ts` — mock shape updated (exported but currently unused)

The internal `WeekContent.classroomUrl` field and `getAssignmentLink()` are unchanged — they just now receive the real API value. Both the week tab and the exercises tab share this resolution path, so both are fixed.

## Notes

- `npx tsc --noEmit` passes clean.
- Nothing in the codebase currently *sends* an assignment-URL update, so the `UpdateCohortWeekRequestDto` field name was matched to the response on assumption. If an admin edit is wired up later, confirm the PATCH body key the backend expects.

## Verification

Confirmed live: with stale data cleared, the LN season-3 instruction sheet now links to `…/assignments/s3-week-1-generating-lightning-invoice` (and the other exercise weeks) instead of the static fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)