### PR TITLE
feat(profile): add portfolio and LinkedIn profile links

### DIFF
--- a/src/components/student/ProfileDataCard.tsx
+++ b/src/components/student/ProfileDataCard.tsx
@@ -1,5 +1,5 @@
 import { Box, Typography, Chip, Link, Divider } from '@mui/material';
-import { User, MapPin, Github, Book, Clock, MessageSquare } from 'lucide-react';
+import { User, MapPin, Github, Briefcase, Linkedin, Book, Clock, MessageSquare } from 'lucide-react';
 
 interface ProfileData {
   id?: string;
@@ -11,6 +11,8 @@ interface ProfileData {
   description?: string;
   background?: string;
   githubProfileUrl?: string;
+  portfolioUrl?: string;
+  linkedinProfileUrl?: string;
   skills?: string[];
   firstHeardAboutBitcoinOn?: string;
   bitcoinBooksRead?: string[];
@@ -68,6 +70,48 @@ export const ProfileDataCard = ({ profile }: ProfileDataCardProps) => {
                 sx={{ color: '#60a5fa', fontSize: '1rem', '&:hover': { color: '#93c5fd' } }}
               >
                 {profile.githubProfileUrl}
+              </Link>
+            </Box>
+          </>
+        )}
+
+        {/* Portfolio */}
+        {profile.portfolioUrl && (
+          <>
+            <Divider sx={{ borderColor: '#27272a' }} />
+            <Box>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                <Briefcase size={18} color="#fb923c" />
+                <Typography sx={{ fontWeight: 600, color: '#fb923c', fontSize: '0.95rem' }}>Portfolio</Typography>
+              </Box>
+              <Link
+                href={profile.portfolioUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                sx={{ color: '#60a5fa', fontSize: '1rem', '&:hover': { color: '#93c5fd' } }}
+              >
+                {profile.portfolioUrl}
+              </Link>
+            </Box>
+          </>
+        )}
+
+        {/* LinkedIn */}
+        {profile.linkedinProfileUrl && (
+          <>
+            <Divider sx={{ borderColor: '#27272a' }} />
+            <Box>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                <Linkedin size={18} color="#fb923c" />
+                <Typography sx={{ fontWeight: 600, color: '#fb923c', fontSize: '0.95rem' }}>LinkedIn</Typography>
+              </Box>
+              <Link
+                href={profile.linkedinProfileUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                sx={{ color: '#60a5fa', fontSize: '1rem', '&:hover': { color: '#93c5fd' } }}
+              >
+                {profile.linkedinProfileUrl}
               </Link>
             </Box>
           </>

--- a/src/components/student/StudentProfileData.tsx
+++ b/src/components/student/StudentProfileData.tsx
@@ -28,6 +28,8 @@ interface UserProfile {
   description: string | null;
   background: string | null;
   githubProfileUrl: string | null;
+  portfolioUrl: string | null;
+  linkedinProfileUrl: string | null;
   skills: string[];
   firstHeardAboutBitcoinOn: string | null;
   bitcoinBooksRead: string[];
@@ -263,7 +265,7 @@ const StudentProfileData: React.FC = () => {
                 <Typography sx={hintSx}>Use the email linked to your Discord so roles are assigned correctly.</Typography>
               </Box>
               <Box>
-                <Typography variant="body2" sx={labelSx}>Portfolio / GitHub / Side-project link*</Typography>
+                <Typography variant="body2" sx={labelSx}>GitHub*</Typography>
                 <TextField
                   fullWidth
                   name="githubProfileUrl"
@@ -272,7 +274,35 @@ const StudentProfileData: React.FC = () => {
                   onChange={handleInputChange}
                   required
                   size="small"
+                  placeholder="https://github.com/"
+                  sx={inputSx}
+                />
+              </Box>
+              <Box>
+                <Typography variant="body2" sx={labelSx}>Portfolio / Side Project</Typography>
+                <TextField
+                  fullWidth
+                  name="portfolioUrl"
+                  type="url"
+                  value={profile.portfolioUrl || ''}
+                  onChange={handleInputChange}
+                  size="small"
                   placeholder="https://"
+                  slotProps={{ htmlInput: { maxLength: 2048 } }}
+                  sx={inputSx}
+                />
+              </Box>
+              <Box>
+                <Typography variant="body2" sx={labelSx}>LinkedIn</Typography>
+                <TextField
+                  fullWidth
+                  name="linkedinProfileUrl"
+                  type="url"
+                  value={profile.linkedinProfileUrl || ''}
+                  onChange={handleInputChange}
+                  size="small"
+                  placeholder="https://www.linkedin.com/"
+                  slotProps={{ htmlInput: { maxLength: 2048 } }}
                   sx={inputSx}
                 />
               </Box>

--- a/src/pages/myProfile/profilePage.tsx
+++ b/src/pages/myProfile/profilePage.tsx
@@ -57,6 +57,8 @@ const ProfilePage: React.FC = () => {
     description: string | null;
     background: string | null;
     githubProfileUrl: string | null;
+    portfolioUrl: string | null;
+    linkedinProfileUrl: string | null;
     skills: string[];
     firstHeardAboutBitcoinOn: string | null;
     bitcoinBooksRead: string[];
@@ -75,6 +77,8 @@ const ProfilePage: React.FC = () => {
     description: null,
     background: null,
     githubProfileUrl: null,
+    portfolioUrl: null,
+    linkedinProfileUrl: null,
     skills: [],
     firstHeardAboutBitcoinOn: null,
     bitcoinBooksRead: [],
@@ -89,7 +93,9 @@ const ProfilePage: React.FC = () => {
     { label: "Discord Display Name", id: "discordGlobalName", value: profile.discordGlobalName },
     { label: "Name", id: "name", value: profile.name },
     { label: "Role", id: "role", value: profile.role },
-    { label: "GitHub Profile", id: "githubProfileUrl", value: profile.githubProfileUrl, type: "url" },
+    { label: "GitHub", id: "githubProfileUrl", value: profile.githubProfileUrl, type: "url" },
+    { label: "Portfolio / Side Project", id: "portfolioUrl", value: profile.portfolioUrl, type: "url" },
+    { label: "LinkedIn", id: "linkedinProfileUrl", value: profile.linkedinProfileUrl, type: "url" },
     { label: "Location", id: "location", value: profile.location },
     { label: "First Heard Bitcoin On", id: "firstHeardAboutBitcoinOn", value: profile.firstHeardAboutBitcoinOn },
     { label: "Why Bitcoin", id: "whyBitcoin", value: profile.whyBitcoin },

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -202,6 +202,8 @@ export interface UpdateUserRequest {
   description?: string;
   background?: string;
   githubProfileUrl?: string;
+  portfolioUrl?: string;
+  linkedinProfileUrl?: string;
   skills?: string[];
   firstHeardAboutBitcoinOn?: string;
   bitcoinBooksRead?: string[];
@@ -226,6 +228,8 @@ export interface GetUserResponse {
   description: string | null;
   background: string | null;
   githubProfileUrl: string | null;
+  portfolioUrl: string | null;
+  linkedinProfileUrl: string | null;
   skills: string[] | null;
   // ISO date (YYYY-MM-DD) of when first heard about Bitcoin
   firstHeardAboutBitcoinOn: string | null;


### PR DESCRIPTION
Mirror the existing githubProfileUrl handling for two new optional fields, portfolioUrl and linkedinProfileUrl, across type definitions, the profile edit form, the read-only profile card, and the legacy profile page. Both are optional and never gate profile completion.